### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,8 +5,9 @@ TOKEN=$1
 PR_NUMBER=$2
 ORG_REPO=$3
 
-ORG=${ORG_REPO%%/*}
-REPO=${ORG_REPO#*/}
+IFS='/' read -ra SPLIT_REPO <<< "$ORG_REPO"
+ORG=${SPLIT_REPO[0]}
+REPO=${SPLIT_REPO[1]}
 
 gh auth login --with-token <<< "$TOKEN"
 
@@ -41,9 +42,6 @@ get_codeql_conclusion() {
 }
 
 conclusion=$(get_codeql_conclusion)
-# Output ORG and REPO to the logs
-echo "ORG: $ORG"
-echo "REPO: $REPO"
 if [ "$conclusion" != "SUCCESS" ]; then
   echo "CodeQL check failed"
   exit 1


### PR DESCRIPTION
This pull request primarily modifies the `run.sh` script to improve code readability and remove unnecessary logging. The most significant changes include refactoring the way the `ORG` and `REPO` variables are assigned and removing the logging of these variables.

Changes to `run.sh`:

* Changed the way `ORG` and `REPO` variables are assigned: Instead of using string manipulation, the script now uses the `read` command to split the `ORG_REPO` variable into `ORG` and `REPO` variables. This change improves code readability and maintainability.
* Removed logging of `ORG` and `REPO` variables: The logging of these variables was deemed unnecessary and thus removed, making the script output cleaner.