### PR TITLE
Update run.sh to handle GraphQL responses correctly

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+trap 'echo "An error occurred. Exiting." >&2' ERR
 
 TOKEN=$1
 PR_NUMBER=$2
@@ -41,14 +42,21 @@ get_codeql_conclusion() {
   echo $response | jq -r '.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[0].checkRuns.nodes[0].conclusion'
 }
 
+declare -r JOB_SKIPPED=78
+declare -r JOB_FAILED=1
+declare -r JOB_SUCCESS=0
+
 conclusion=$(get_codeql_conclusion)
+exit_status=$JOB_SUCCESS
+
 if [ "$conclusion" == "SUCCESS" ]; then
   echo "CodeQL check succeeded"
-  exit 0
 elif [ "$conclusion" == "FAILURE" ]; then
   echo "CodeQL check failed"
-  exit 1
+  exit_status=$JOB_FAILED
 else
-  echo "CodeQL check conclusion is neither SUCCESS nor FAILURE. Skipping job."
-  exit 78
+  echo "Unexpected CodeQL conclusion received: $conclusion. Please check the CodeQL job for more details. Skipping job."
+  exit_status=$JOB_SKIPPED
 fi
+
+exit $exit_status

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,13 @@ get_codeql_conclusion() {
 }
 
 conclusion=$(get_codeql_conclusion)
-if [ "$conclusion" != "SUCCESS" ]; then
+if [ "$conclusion" == "SUCCESS" ]; then
+  echo "CodeQL check succeeded"
+  exit 0
+elif [ "$conclusion" == "FAILURE" ]; then
   echo "CodeQL check failed"
   exit 1
+else
+  echo "CodeQL check conclusion is neither SUCCESS nor FAILURE. Skipping job."
+  exit 78
 fi

--- a/test/sample-graphql-responses/failure.json
+++ b/test/sample-graphql-responses/failure.json
@@ -1,0 +1,31 @@
+{
+    "data": {
+        "repository": {
+            "pullRequest": {
+                "commits": {
+                    "nodes": [
+                        {
+                            "commit": {
+                                "checkSuites": {
+                                    "nodes": [
+                                        {
+                                            "checkRuns": {
+                                                "nodes": [
+                                                    {
+                                                        "name": "CodeQL",
+                                                        "status": "COMPLETED",
+                                                        "conclusion": "FAILURE"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/sample-graphql-responses/neutral.json
+++ b/test/sample-graphql-responses/neutral.json
@@ -1,0 +1,31 @@
+{
+    "data": {
+        "repository": {
+            "pullRequest": {
+                "commits": {
+                    "nodes": [
+                        {
+                            "commit": {
+                                "checkSuites": {
+                                    "nodes": [
+                                        {
+                                            "checkRuns": {
+                                                "nodes": [
+                                                    {
+                                                        "name": "CodeQL",
+                                                        "status": "COMPLETED",
+                                                        "conclusion": "NEUTRAL"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/sample-graphql-responses/success.json
+++ b/test/sample-graphql-responses/success.json
@@ -1,0 +1,31 @@
+{
+    "data": {
+        "repository": {
+            "pullRequest": {
+                "commits": {
+                    "nodes": [
+                        {
+                            "commit": {
+                                "checkSuites": {
+                                    "nodes": [
+                                        {
+                                            "checkRuns": {
+                                                "nodes": [
+                                                    {
+                                                        "name": "CodeQL",
+                                                        "status": "COMPLETED",
+                                                        "conclusion": "SUCCESS"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Updates the GitHub Action script `run.sh` to correctly handle GraphQL responses for CodeQL check conclusions.

- **Handles "SUCCESS" and "FAILURE" conclusions**: Modifies the `get_codeql_conclusion` function to explicitly check for "SUCCESS" and "FAILURE" conclusions. Passes the job if the conclusion is "SUCCESS" and fails the job if the conclusion is "FAILURE".
- **Implements skipping logic**: Adds a condition to skip the job for conclusions other than "SUCCESS" or "FAILURE", using exit code 78 to differentiate this skip condition from a fail condition.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Eldrick19/code-scanning-status-checker?shareId=2f505e97-659c-4e28-9534-378fe2d817b1).